### PR TITLE
Scope warehouse git subscription to apps/team_daniel

### DIFF
--- a/kargo/kargo-custom/team_daniel/warehouse.yaml
+++ b/kargo/kargo-custom/team_daniel/warehouse.yaml
@@ -10,5 +10,7 @@ spec:
   - git:
       repoURL: https://github.com/akuity/sedemo-platform
       branch: main
+      includePaths:
+      - apps/team_daniel/**
   - image:
       repoURL: ghcr.io/dhpup/guestbook


### PR DESCRIPTION
Scopes the team-daniel warehouse to only watch `apps/team_daniel/**` instead of the entire repository.

This prevents unnecessary freight creation from unrelated repo changes.