### PR TITLE
Add team-daniel ArgoCD AppProject

### DIFF
--- a/apps/team-daniel/application-set.yaml
+++ b/apps/team-daniel/application-set.yaml
@@ -17,7 +17,7 @@ spec:
       annotations:
         kargo.akuity.io/authorized-stage: team-daniel:{{stage}}
     spec:
-      project: default
+      project: team-daniel
       source:
         repoURL: https://github.com/akuity/sedemo-platform
         targetRevision: stage/team-daniel/{{stage}}

--- a/apps/team-daniel/appproject.yaml
+++ b/apps/team-daniel/appproject.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: team-daniel
+  namespace: argocd
+spec:
+  description: Team Daniel's ArgoCD project
+  sourceRepos:
+    - '*'
+  destinations:
+    - server: '*'
+      name: '*'
+      namespace: '*'
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'


### PR DESCRIPTION
- Creates a new ArgoCD AppProject for team-daniel with same permissions as default project
- Updates ApplicationSet to use project: team-daniel instead of default