### PR TITLE
feat: add intelligence-demo migrated from akp-demo

### DIFF
--- a/apps/intelligence-demo/application-set.yaml
+++ b/apps/intelligence-demo/application-set.yaml
@@ -1,0 +1,73 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: intelligence-demo-guestbook
+  namespace: argocd
+spec:
+  generators:
+  - list:
+      elements:
+      - stage: dev
+      - stage: staging
+      - stage: prod
+  template:
+    metadata:
+      name: intelligence-demo-guestbook-{{stage}}
+      annotations:
+        kargo.akuity.io/authorized-stage: intelligence-demo:{{stage}}
+    spec:
+      project: intelligence-demo
+      source:
+        repoURL: https://github.com/akuity/sedemo-platform
+        targetRevision: main
+        path: apps/intelligence-demo/guestbook/chart
+        helm:
+          releaseName: "{{stage}}"
+          valueFiles:
+          - values-{{stage}}.yaml
+      destination:
+        name: sedemo-primary
+        namespace: intelligence-demo
+      syncPolicy:
+        syncOptions:
+        - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: intelligence-demo-prod-oom
+  namespace: argocd
+  annotations:
+    kargo.akuity.io/authorized-stage: intelligence-demo:prod-oom
+spec:
+  project: intelligence-demo
+  source:
+    repoURL: https://github.com/akuity/sedemo-platform
+    targetRevision: main
+    path: apps/intelligence-demo/oom-demo
+  destination:
+    name: sedemo-primary
+    namespace: intelligence-demo
+  syncPolicy:
+    syncOptions:
+    - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: intelligence-demo-prod-crashloop
+  namespace: argocd
+  annotations:
+    kargo.akuity.io/authorized-stage: intelligence-demo:prod-crashloop
+spec:
+  project: intelligence-demo
+  source:
+    repoURL: https://github.com/akuity/sedemo-platform
+    targetRevision: main
+    path: apps/intelligence-demo/crashloop-demo
+  destination:
+    name: sedemo-primary
+    namespace: intelligence-demo
+  syncPolicy:
+    syncOptions:
+    - CreateNamespace=true

--- a/apps/intelligence-demo/appproject.yaml
+++ b/apps/intelligence-demo/appproject.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: intelligence-demo
+  namespace: argocd
+spec:
+  description: Intelligence Demo with OOM and Crashloop scenarios
+  sourceRepos:
+    - '*'
+  destinations:
+    - server: '*'
+      name: '*'
+      namespace: '*'
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'

--- a/apps/intelligence-demo/crashloop-demo/manifest.yaml
+++ b/apps/intelligence-demo/crashloop-demo/manifest.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crashloop-demo
+spec:
+  minReadySeconds: 5
+  progressDeadlineSeconds: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: crashloop-demo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: crashloop-demo
+    spec:
+      containers:
+        - name: guestbook
+          image: ghcr.io/akuity/guestbook:v0.0.2
+          command:
+          - /app/guestbook
+          args:
+          - --port=3000
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: 2
+            httpGet:
+              path: /
+              port: 30000
+              scheme: HTTP
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 30000
+          resources:
+            limits:
+              cpu: 100m
+              memory: 32Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000

--- a/apps/intelligence-demo/guestbook/chart/Chart.yaml
+++ b/apps/intelligence-demo/guestbook/chart/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: guestbook
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.0.1"

--- a/apps/intelligence-demo/guestbook/chart/templates/NOTES.txt
+++ b/apps/intelligence-demo/guestbook/chart/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "guestbook.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "guestbook.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "guestbook.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "guestbook.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/apps/intelligence-demo/guestbook/chart/templates/_helpers.tpl
+++ b/apps/intelligence-demo/guestbook/chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "guestbook.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "guestbook.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" $name .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "guestbook.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "guestbook.labels" -}}
+helm.sh/chart: {{ include "guestbook.chart" . }}
+{{ include "guestbook.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "guestbook.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "guestbook.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "guestbook.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "guestbook.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/apps/intelligence-demo/guestbook/chart/templates/deployment.yaml
+++ b/apps/intelligence-demo/guestbook/chart/templates/deployment.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "guestbook.fullname" . }}
+  labels:
+    {{- include "guestbook.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "guestbook.selectorLabels" . | nindent 6 }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "guestbook.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          {{- if .Values.env }}
+          env:
+            {{- range .Values.env }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/apps/intelligence-demo/guestbook/chart/templates/ingress.yaml
+++ b/apps/intelligence-demo/guestbook/chart/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "guestbook.fullname" . }}
+  labels:
+    {{- include "guestbook.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "guestbook.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/apps/intelligence-demo/guestbook/chart/templates/service.yaml
+++ b/apps/intelligence-demo/guestbook/chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "guestbook.fullname" . }}
+  labels:
+    {{- include "guestbook.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "guestbook.selectorLabels" . | nindent 4 }}

--- a/apps/intelligence-demo/guestbook/chart/values-dev.yaml
+++ b/apps/intelligence-demo/guestbook/chart/values-dev.yaml
@@ -1,0 +1,1 @@
+# Dev stage values

--- a/apps/intelligence-demo/guestbook/chart/values-prod.yaml
+++ b/apps/intelligence-demo/guestbook/chart/values-prod.yaml
@@ -1,0 +1,1 @@
+# Prod stage values

--- a/apps/intelligence-demo/guestbook/chart/values-staging.yaml
+++ b/apps/intelligence-demo/guestbook/chart/values-staging.yaml
@@ -1,0 +1,1 @@
+# Staging stage values

--- a/apps/intelligence-demo/guestbook/chart/values.yaml
+++ b/apps/intelligence-demo/guestbook/chart/values.yaml
@@ -1,0 +1,93 @@
+# Default values for guestbook.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: ghcr.io/akuity/guestbook
+  # This sets the pull policy for images.
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+
+minReadySeconds: 10
+progressDeadlineSeconds: 20
+
+env: []
+  # - name: CONSUME_MEMORY_MB
+  #   value: "180"
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 80
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 32Mi
+  requests:
+    cpu: 10m
+    memory: 32Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/apps/intelligence-demo/oom-demo/manifest.yaml
+++ b/apps/intelligence-demo/oom-demo/manifest.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oom-demo
+spec:
+  minReadySeconds: 5
+  progressDeadlineSeconds: 10
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: oom
+      app.kubernetes.io/name: oom-demo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: oom
+        app.kubernetes.io/name: oom-demo
+    spec:
+      containers:
+        - args:
+            - '--vm'
+            - '1'
+            - '--vm-bytes'
+            - 150M
+            - '--vm-hang'
+            - '1'
+          command:
+            - stress
+          image: polinux/stress
+          imagePullPolicy: Always
+          name: oom
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000

--- a/apps/intelligence-demo/runbooks/oom.md
+++ b/apps/intelligence-demo/runbooks/oom.md
@@ -1,0 +1,19 @@
+## General
+
+- First, do the initial triage and collect the basic information to understand the incident.
+- Next, send a slack notification with the link to the conversation to channel "PLEASE REPLACE" with basic detail.
+- Next, work on the incident according to the runbook. Don't take any action automatically, ask for approval.
+- If the app is stable, check 30 seconds later again, then you can close the incident automatically. Please do slack all the details in concise messages.
+- If you stack send a slack message again and mention that you need help.
+- Please ensure you send slack message with the link to the conversation, so engineer can work with you together if needed.
+
+## Out of memory
+
+**Symptoms**: Pod unexpectedly dies with `OOMKilled` status.
+
+**Root cause**: The pod is consuming more memory than the available memory.
+
+**Solution**:
+
+* Temporary increase the memory limit of the pod automatically
+* Increase the memory limit with the 50 Mb increment until the pod is stable.

--- a/kargo/kargo-custom/intelligence-demo/README.md
+++ b/kargo/kargo-custom/intelligence-demo/README.md
@@ -1,0 +1,44 @@
+# Intelligence Demo
+
+This demo is migrated from https://github.com/dhpup/akp-demo and demonstrates Akuity Platform capabilities including:
+
+- Guestbook application with progressive delivery through dev → staging → prod
+- OOM (Out of Memory) demo for incident response scenarios
+- Crashloop demo for debugging scenarios
+
+## Structure
+
+### ArgoCD Applications (`apps/intelligence-demo/`)
+- **appproject.yaml** - ArgoCD project definition
+- **application-set.yaml** - ApplicationSet for guestbook stages + individual apps for OOM/crashloop demos
+- **guestbook/chart/** - Helm chart for the guestbook application
+- **oom-demo/** - Deployment that intentionally triggers OOM
+- **crashloop-demo/** - Deployment that intentionally crashloops
+- **runbooks/** - Runbook documentation for incident response
+
+### Kargo Resources (`kargo/kargo-custom/intelligence-demo/`)
+- **project.yaml** - Kargo project with auto-promotion for crashloop stage
+- **warehouse.yaml** - Watches `ghcr.io/akuity/guestbook` images
+- **stages.yaml** - Five stages: dev, staging, prod, prod-oom, prod-crashloop
+- **tasks.yaml** - Promotion tasks for updating Helm values or sync-only
+
+## Stages
+
+### Dev → Staging → Prod
+Progressive delivery of guestbook application with image tag updates via Helm.
+
+### Prod-OOM
+Sync-only promotion - demonstrates OOM scenario for incident response training.
+
+### Prod-Crashloop
+Auto-promoted, sync-only - demonstrates crashloop scenario for debugging.
+
+## Deployment
+
+```bash
+# Apply ArgoCD resources
+kubectl apply -f apps/intelligence-demo/
+
+# Apply Kargo resources  
+kubectl apply -f kargo/kargo-custom/intelligence-demo/
+```

--- a/kargo/kargo-custom/intelligence-demo/project.yaml
+++ b/kargo/kargo-custom/intelligence-demo/project.yaml
@@ -1,0 +1,19 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: intelligence-demo
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: intelligence-demo
+  namespace: intelligence-demo
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  promotionPolicies:
+  - stageSelector:
+      name: prod-crashloop
+    autoPromotionEnabled: true

--- a/kargo/kargo-custom/intelligence-demo/stages.yaml
+++ b/kargo/kargo-custom/intelligence-demo/stages.yaml
@@ -1,0 +1,94 @@
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: dev
+  namespace: intelligence-demo
+spec:
+  requestedFreight:
+  - origin:
+      kind: Warehouse
+      name: guestbook
+    sources:
+      direct: true
+  promotionTemplate:
+    spec:
+      steps:
+      - task:
+          name: promote
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: staging
+  namespace: intelligence-demo
+spec:
+  requestedFreight:
+  - origin:
+      kind: Warehouse
+      name: guestbook
+    sources:
+      stages:
+      - dev
+  promotionTemplate:
+    spec:
+      steps:
+      - task:
+          name: promote
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: prod
+  namespace: intelligence-demo
+spec:
+  requestedFreight:
+  - origin:
+      kind: Warehouse
+      name: guestbook
+    sources:
+      stages:
+      - staging
+  promotionTemplate:
+    spec:
+      steps:
+      - task:
+          name: promote
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: prod-oom
+  namespace: intelligence-demo
+spec:
+  requestedFreight:
+  - origin:
+      kind: Warehouse
+      name: guestbook
+    sources:
+      stages:
+      - staging
+  promotionTemplate:
+    spec:
+      steps:
+      - task:
+          name: promote-sync-only
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: prod-crashloop
+  namespace: intelligence-demo
+spec:
+  requestedFreight:
+  - origin:
+      kind: Warehouse
+      name: guestbook
+    sources:
+      stages:
+      - staging
+  promotionTemplate:
+    spec:
+      steps:
+      - task:
+          name: promote-sync-only

--- a/kargo/kargo-custom/intelligence-demo/tasks.yaml
+++ b/kargo/kargo-custom/intelligence-demo/tasks.yaml
@@ -1,0 +1,32 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: PromotionTask
+metadata:
+  name: promote
+  namespace: intelligence-demo
+spec:
+  steps:
+  - uses: argocd-update
+    config:
+      apps:
+      - name: intelligence-demo-guestbook-${{ ctx.stage }}
+        sources:
+        - helm:
+            images:
+            - key: image.tag
+              value: ${{ imageFrom("ghcr.io/akuity/guestbook").Tag }}
+          repoURL: https://github.com/akuity/sedemo-platform.git
+---
+# This promotion will only sync the application without updating the image
+apiVersion: kargo.akuity.io/v1alpha1
+kind: PromotionTask
+metadata:
+  name: promote-sync-only
+  namespace: intelligence-demo
+spec:
+  steps:
+  - uses: argocd-update
+    config:
+      apps:
+      - name: intelligence-demo-${{ ctx.stage }}
+        sources:
+        - repoURL: https://github.com/akuity/sedemo-platform.git

--- a/kargo/kargo-custom/intelligence-demo/warehouse.yaml
+++ b/kargo/kargo-custom/intelligence-demo/warehouse.yaml
@@ -1,0 +1,11 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: guestbook
+  namespace: intelligence-demo
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  subscriptions:
+  - image:
+      repoURL: ghcr.io/akuity/guestbook


### PR DESCRIPTION
## Summary
Migrates the complete demo from https://github.com/dhpup/akp-demo to the sedemo-platform repository.

## Changes

### Apps (`apps/intelligence-demo/`)
- **appproject.yaml** - ArgoCD project definition
- **application-set.yaml** - ApplicationSet for guestbook stages + individual apps for OOM/crashloop demos
- **guestbook/chart/** - Complete Helm chart with dev/staging/prod value files
- **oom-demo/** - Deployment that intentionally triggers OOM for incident response training
- **crashloop-demo/** - Deployment that intentionally crashloops for debugging scenarios
- **runbooks/** - Runbook documentation for incident response

### Kargo (`kargo/kargo-custom/intelligence-demo/`)
- **project.yaml** - Kargo Project + ProjectConfig with auto-promotion for crashloop stage
- **warehouse.yaml** - Watches `ghcr.io/akuity/guestbook` images
- **stages.yaml** - 5 stages: dev, staging, prod, prod-oom, prod-crashloop
- **tasks.yaml** - Promotion tasks for Helm updates and sync-only operations
- **README.md** - Documentation

## Testing
- [ ] ArgoCD applications deploy successfully
- [ ] Kargo stages promote correctly
- [ ] OOM demo triggers expected behavior
- [ ] Crashloop demo triggers expected behavior