### PR TITLE
refactor: rename intelligence-demo-guestbook to intelligence-demo

### DIFF
--- a/apps/intelligence-demo/application-set.yaml
+++ b/apps/intelligence-demo/application-set.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-  name: intelligence-demo-guestbook
+  name: intelligence-demo
   namespace: argocd
 spec:
   generators:
@@ -12,7 +12,7 @@ spec:
       - stage: prod
   template:
     metadata:
-      name: intelligence-demo-guestbook-{{stage}}
+      name: intelligence-demo-{{stage}}
       annotations:
         kargo.akuity.io/authorized-stage: intelligence-demo:{{stage}}
     spec:

--- a/kargo/kargo-custom/intelligence-demo/tasks.yaml
+++ b/kargo/kargo-custom/intelligence-demo/tasks.yaml
@@ -8,7 +8,7 @@ spec:
   - uses: argocd-update
     config:
       apps:
-      - name: intelligence-demo-guestbook-${{ ctx.stage }}
+      - name: intelligence-demo-${{ ctx.stage }}
         sources:
         - helm:
             images:


### PR DESCRIPTION
## Summary
Remove 'guestbook' suffix from ApplicationSet and app names for cleaner naming.

## Changes
- `apps/intelligence-demo/application-set.yaml`: Renamed `intelligence-demo-guestbook` → `intelligence-demo` and `intelligence-demo-guestbook-{{stage}}` → `intelligence-demo-{{stage}}`
- `kargo/kargo-custom/intelligence-demo/tasks.yaml`: Updated promote task to reference `intelligence-demo-${{ ctx.stage }}`